### PR TITLE
fix: mangle not applied to ids

### DIFF
--- a/services/google-sheets.js
+++ b/services/google-sheets.js
@@ -73,6 +73,7 @@ export const fetchTSV = async (url = constants.tsvUrl) => {
         })
         const hash = (r, ids, names, m = t => t) => {
             for (let id of ids) {
+                id = m(id)
                 r.byId[id] = [...(r.byId[id] || []), i]
             }
 

--- a/services/google-sheets.js
+++ b/services/google-sheets.js
@@ -27,7 +27,7 @@ class Classifier {
     nameMap = {};
     mangle = t => t;
 
-    constructor(self, mangle) {
+    constructor(mangle) {
         if (mangle)
             this.mangle = mangle
     }

--- a/services/google-sheets.js
+++ b/services/google-sheets.js
@@ -71,17 +71,17 @@ export const fetchTSV = async (url = constants.tsvUrl) => {
                 console.error(`${i}: error in ${f}`, event[f], r)
             }
         })
-        const hash = (r, ids, names, m = t => t) => {
+        const hash = (category, ids, names, mangle = t => t) => {
             for (let id of ids) {
-                id = m(id)
-                r.byId[id] = [...(r.byId[id] || []), i]
+                id = mangle(id)
+                category.byId[id] = [...(category.byId[id] || []), i]
             }
 
-            for (let c of names) {
-                c = m(c)
-                r.byName[c] = [...(r.byName[c] || []), i]
+            for (let name of names) {
+                name = mangle(name)
+                category.byName[name] = [...(category.byName[name] || []), i]
             }
-            return r;
+            return category;
         }
         hash(tipos, event.tipoId, event.tipo, FIXUP)
         hash(componentes, event.componenteId, event.componente, FIXUP)

--- a/services/google-sheets.js
+++ b/services/google-sheets.js
@@ -32,7 +32,7 @@ class Classifier {
             this.mangle = mangle
     }
 
-    clasify (ids, names, i) {
+    classify (ids, names, i) {
 
         for (let id of ids) {
             id = this.mangle(id)
@@ -96,8 +96,8 @@ export const fetchTSV = async (url = constants.tsvUrl) => {
                 console.error(`${i}: error in ${f}`, event[f], r)
             }
         })
-        tipos.clasify(event.tipoId, event.tipo, i)
-        componentes.clasify(event.componenteId, event.componente, i)
+        tipos.classify(event.tipoId, event.tipo, i)
+        componentes.classify(event.componenteId, event.componente, i)
     }
     return {cases, tipos, componentes, min, max}
 }

--- a/services/google-sheets.js
+++ b/services/google-sheets.js
@@ -25,22 +25,23 @@ class Classifier {
     byName = {};
     idMap = {};
     nameMap = {};
+    mangle = t => t;
 
-    constructor(self, mangle = t => t) {
-        this.mangle = mangle
+    constructor(self, mangle) {
+        if (mangle)
+            this.mangle = mangle
     }
 
     clasify (ids, names, i) {
 
-            for (let id of ids) {
-                id = thismangle(id)
-                this.byId[id] = [...(this.byId[id] || []), i]
-            }
+        for (let id of ids) {
+            id = this.mangle(id)
+            this.byId[id] = [...(this.byId[id] || []), i]
+        }
 
-            for (let name of names) {
-                name = mangle(name)
-                this.byName[name] = [...(this.byName[name] || []), i]
-            }
+        for (let name of names) {
+            name = this.mangle(name)
+            this.byName[name] = [...(this.byName[name] || []), i]
         }
     }
 }


### PR DESCRIPTION
    
    the data entry process is quite broken... we get a lot of duplicated
    keys, mistiped/slightly different wording, for this we introduced a
    FIXUPS function stack, but weren't applying it to the ID field,
    generating duplication in the analisis tab.
