### PR TITLE
#Closes 33 - first pop up css fix

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,5 +18,6 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    'linebreak-style': 0,
   },
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,1 @@
-{}
+{"endOfLine": "auto" }

--- a/src/components/Markers.jsx
+++ b/src/components/Markers.jsx
@@ -29,7 +29,7 @@ export const Markers = ({
   }, [data, tipoFilters]);
 
   const renderMarker = (event) => {
-    const { coords, title, date, source, id, tipoId, tipo } = event;
+    const { coords, title, date, source, id, tipoId } = event;
     // Document this: Where does 'hovered' come from? It's not in the stylesheet
     const markerStyle = `${styles.circulo} ${id === selected ? "hovered" : ""} ${tipoIdStyles[tipoId]}`;
 
@@ -47,7 +47,6 @@ export const Markers = ({
               lng: coords.longitude,
             },
             title,
-            tipo,
             date,
             source,
           })

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -4,8 +4,6 @@ import PropTypes from "prop-types";
 const Popup = ({ title, date, source, tipo }) => (
   <div className={styles.popup}>
     <h3 className={styles.displayTitulo}>{title}</h3>
-    <p className={styles.displayTipo}>{tipo.join(" ")}</p>
-
     <div className={styles.masDatosPopup}>
       {" "}
       <p className={styles.displayFecha}>Fecha: {date.toLocaleDateString()}</p>

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -1,7 +1,7 @@
 import styles from "./Popup.module.css";
 import PropTypes from "prop-types";
 
-const Popup = ({ title, date, source}) => (
+const Popup = ({ title, date, source }) => (
   <div className={styles.popup}>
     <h3 className={styles.displayTitulo}>{title}</h3>
     <div className={styles.masDatosPopup}>

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -1,7 +1,7 @@
 import styles from "./Popup.module.css";
 import PropTypes from "prop-types";
 
-const Popup = ({ title, date, source, tipo }) => (
+const Popup = ({ title, date, source}) => (
   <div className={styles.popup}>
     <h3 className={styles.displayTitulo}>{title}</h3>
     <div className={styles.masDatosPopup}>
@@ -23,7 +23,6 @@ Popup.propTypes = {
   title: PropTypes.string.isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
   source: PropTypes.string.isRequired,
-  tipo: PropTypes.array.isRequired,
 };
 
 export default Popup;

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -8,7 +8,7 @@ const Popup = ({ title, date, source, tipo }) => (
 
     <div className={styles.masDatosPopup}>
       {" "}
-      <p>Fecha: {date.toLocaleDateString()}</p>
+      <p className={styles.displayFecha}>Fecha: {date.toLocaleDateString()}</p>
       <a
         className={styles.displayLink}
         href={source}

--- a/src/components/Popup.module.css
+++ b/src/components/Popup.module.css
@@ -27,6 +27,12 @@
   color: white;
 }
 
+.displayFecha {
+  font-size: 0.8rem;
+  color: white;
+  padding-top: 2vh;
+}
+
 .displayTipo {
   font-size: 0.7rem;
   color: lightblue;
@@ -43,6 +49,26 @@
   height: 5vh;
 }
 
+/*celus mas grandes*/
+@media (min-width: 400px) {
+  .popup {
+    position: absolute;
+    top: 65vh;
+    left: 2vw;
+    width: 96vw;
+    height: 17vh;
+    padding: 15px;
+    padding-left: 25px;
+    color: white;
+    background-color: #2b3bcd;
+    border: 1px solid white;
+    border-radius: 30px;
+    z-index: 1000;
+    overflow: hidden;
+    white-space: break-spaces;
+  }
+}
+
 @media (min-width: 768px) {
   .popup {
     position: absolute;
@@ -50,9 +76,7 @@
     left: 1vw;
     width: 28vw;
     height: 36vh;
-
     padding: 16px 8px;
-
     white-space: break-spaces;
   }
 
@@ -75,36 +99,15 @@
   .displayLink {
     width: 8vw;
   }
+
   .popup {
     position: absolute;
     top: 63vh;
     left: 1vw;
     width: 18vw;
     height: 32vh;
-
     padding: 16px 8px;
-
     white-space: breakspaces;
   }
 }
 
-/*celus mas grandes*/
-@media (min-width: 400px) {
-  .popup {
-    position: absolute;
-    top: 65vh;
-    left: 2vw;
-    width: 96vw;
-    height: 17vh;
-
-    padding: 15px;
-    padding-left: 25px;
-    color: white;
-    background-color: #2b3bcd;
-    border: 1px solid white;
-    border-radius: 30px;
-    z-index: 1000;
-    overflow: hidden;
-    white-space: break-spaces;
-  }
-}

--- a/src/components/Popup.module.css
+++ b/src/components/Popup.module.css
@@ -33,10 +33,6 @@
   padding-top: 2vh;
 }
 
-.displayTipo {
-  font-size: 0.7rem;
-  color: lightblue;
-}
 
 .displayLink {
   color: white;

--- a/src/components/Popup.module.css
+++ b/src/components/Popup.module.css
@@ -33,7 +33,6 @@
   padding-top: 2vh;
 }
 
-
 .displayLink {
   color: white;
   border: solid;


### PR DESCRIPTION
1. Fix the order of  @media (min-width: 400px) /*celus mas grandes*/ by moving it to line 52. It was causing issues with @media (min-width: 768px) and @media (min-width: 1200px).

https://github.com/edipoarg/radar/blob/d2227556588531f7acc2539ac89f82a237cab22c/src/components/Popup.module.css#L52C1-L70C2

2. Add className={styles.displayFecha} to Popup.jsx and .displayFecha to Popup.module.css. It was deleted during the CSS migration.

https://github.com/edipoarg/radar/blob/d2227556588531f7acc2539ac89f82a237cab22c/src/components/Popup.jsx#L11

https://github.com/edipoarg/radar/blob/d2227556588531f7acc2539ac89f82a237cab22c/src/components/Popup.module.css#L30-L34

