### PR TITLE
#54 - hover style migrates to Markers css module

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,8 +15,3 @@
 }
 
 /* TODO: Check whether this class selector is used within the <Marker /> external component */
-.marker:hover {
-  background-color: rgb(52, 7, 7);
-  /* Increase the size when hovered */
-  transform: scale(1.5);
-}

--- a/src/components/Markers.module.css
+++ b/src/components/Markers.module.css
@@ -57,3 +57,10 @@
 .circulo.rojo {
     background-color: rgb(251, 55, 25);
 }
+
+.circulo:hover {
+    background-color: rgb(52, 7, 7);
+    /* Increase the size when hovered */
+    transform: scale(1.5);
+  }
+  


### PR DESCRIPTION
Moví el código css .marker:hover de App.css a Markers.module.css y lo renombre .ciruclo:hover y se resolvió conflicto del efecto del hover.
Ahora debería hacer lo mismo con el codigo para cuando un marker queda como selected.