### PR TITLE
fix request cascade on page load

### DIFF
--- a/src/helpers/fetchUrlsData.ts
+++ b/src/helpers/fetchUrlsData.ts
@@ -1,11 +1,24 @@
+function fetchSingleUrlData(url: string): Promise<string> {
+  return fetch(url).then((r) => r.json());
+}
+
 export async function fetchUrlsData(
   urls: Record<string, string>,
 ): Promise<Record<string, string>> {
-  const data: Record<string, string> = {};
-  for (const [k, u] of Object.entries(urls)) {
-    await fetch(u).then(async (r) => {
-      data[k] = await r.json();
-    });
-  }
-  return data;
+  /* Convert URLs into an array of promises of tuples consisting of
+   * on one hand, the key of the URL,
+   * and on the other, the response to the URL itself
+   */
+  const keyAndResponsePromises = Object.entries(urls).map(
+    async ([key, url]): Promise<[string, string]> => [
+      key,
+      await fetchSingleUrlData(url),
+    ],
+  );
+  const keyAndResponses = await Promise.all(keyAndResponsePromises);
+  const urlsDataAccumulator: Record<string, string> = {};
+  keyAndResponses.forEach(([key, response]) => {
+    urlsDataAccumulator[key] = response;
+  });
+  return urlsDataAccumulator;
 }


### PR DESCRIPTION
This commit intends to reduce the time-to-load of the page.

The previous fetch function was waiting for the completion of each URL request before making the next one, in order to insert each response into the response object.

This implementation of the fetch function makes a request for every single URL at the same time and only once all responses have been received builds the response object.

In breve, this PR parallelizes the requests at page load for better performance.